### PR TITLE
added getBase64Screenshot function

### DIFF
--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -175,6 +175,11 @@ export default class Webcam extends Component {
     return canvas.toDataURL(this.props.screenshotFormat);
   }
 
+  getBase64Screenshot() {
+    let screenShot = this.getScreenshot();
+    return screenShot.replace(/^data:image\/(png|jpg);base64,/, "");
+  }
+  
   getCanvas() {
     if (!this.state.hasUserMedia) return null;
 


### PR DESCRIPTION
I added a new fucntion in order to get just the base64 string without the information that canvas put inside of the string after call the toDataURL method, i waste lot of time trying to get a pure base64 image to use it in another service so it can be helpful for someone else