### PR TITLE
Update getUserMedia to MediaDevices.getUserMedia()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ for browser compatibility.
 ## Installation
 
 ```
-npm install react-webcam
+npm install @cliener/react-webcam
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ width            | number   | 640          | width of video element
 style            | object   |              | style prop passed to video element
 screenshotFormat | string   | 'image/webp' | format of screenshot
 onUserMedia      | function | noop         | callback when component receives a media stream
-audioSource      | string   |              | an array or single ConstrainDOMString(s) specifying the device id
-videoSource      | string   |              | an array or single ConstrainDOMString(s) specifying the device id
+onFailure        | function | noop         | callback in case an error happens, no getUserMedia for example
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ for browser compatibility.
 ## Installation
 
 ```
-npm install @cliener/react-webcam
+npm install react-webcam
 ```
 
 ## Demo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mozmorris/react-webcam.git"
+    "url": "https://github.com/cliener/react-webcam.git"
   },
   "keywords": [
     "react",
@@ -19,11 +19,15 @@
     "webcam"
   ],
   "author": "Moz Morris <mozmorris@gmail.com>",
+  "contributors": [{
+    "name": "Chris Lienert",
+    "email": "rezonate@gmail.com"
+  }],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mozmorris/react-webcam/issues"
+    "url": "https://github.com/cliener/react-webcam/issues"
   },
-  "homepage": "https://github.com/mozmorris/react-webcam",
+  "homepage": "https://github.com/cliener/react-webcam",
   "peerDependencies": {
     "react": ">=0.14.0",
     "react-dom": ">=0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliener/react-webcam",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliener/react-webcam",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {
@@ -19,10 +19,12 @@
     "webcam"
   ],
   "author": "Moz Morris <mozmorris@gmail.com>",
-  "contributors": [{
-    "name": "Chris Lienert",
-    "email": "rez@iinet.net.au"
-  }],
+  "contributors": [
+    {
+      "name": "Chris Lienert",
+      "email": "rez@iinet.net.au"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/cliener/react-webcam/issues"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Moz Morris <mozmorris@gmail.com>",
   "contributors": [{
     "name": "Chris Lienert",
-    "email": "rezonate@gmail.com"
+    "email": "rez@iinet.net.au"
   }],
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-webcam",
+  "name": "@cliener/react-webcam",
   "version": "0.3.0",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cliener/react-webcam",
+  "name": "react-webcam",
   "version": "0.3.2",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cliener/react-webcam.git"
+    "url": "https://github.com/mozmorris/react-webcam.git"
   },
   "keywords": [
     "react",
@@ -27,9 +27,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/cliener/react-webcam/issues"
+    "url": "https://github.com/mozmorris/react-webcam/issues"
   },
-  "homepage": "https://github.com/cliener/react-webcam",
+  "homepage": "https://github.com/mozmorris/react-webcam",
   "peerDependencies": {
     "react": ">=0.14.0",
     "react-dom": ">=0.14.0"

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -1,60 +1,42 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { findDOMNode } from 'react-dom';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
-function hasGetUserMedia() {
-  return !!(navigator.getUserMedia || navigator.webkitGetUserMedia ||
-            navigator.mozGetUserMedia || navigator.msGetUserMedia);
-}
+const getUserMedia =
+  navigator.mediaDevices &&
+  navigator.mediaDevices.getUserMedia &&
+  navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+
+export const SupportsWebcam = !!getUserMedia;
 
 export default class Webcam extends Component {
   static defaultProps = {
     audio: true,
-    className: '',
+    width: 640,
     height: 480,
     muted: false,
+    screenshotFormat: "image/webp",
     onUserMedia: () => {},
-    screenshotFormat: 'image/webp',
-    width: 640,
-  };
-
-  static propTypes = {
-    audio: PropTypes.bool,
-    muted: PropTypes.bool,
-    onUserMedia: PropTypes.func,
-    height: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
-    width: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.string,
-    ]),
-    screenshotFormat: PropTypes.oneOf([
-      'image/webp',
-      'image/png',
-      'image/jpeg',
-    ]),
-    style: PropTypes.object,
-    className: PropTypes.string,
-    audioSource: PropTypes.string,
-    videoSource: PropTypes.string,
+    onFailure: () => {},
+    className: "",
   };
 
   static mountedInstances = [];
 
   static userMediaRequested = false;
 
-  constructor() {
-    super();
-    this.state = {
-      hasUserMedia: false,
-    };
+  constructor(props) {
+    super(props);
+    if (!SupportsWebcam) {
+      const error = new Error("getUserMedia is not supported by this browser");
+      this.props.onFailure(error);
+    }
   }
 
-  componentDidMount() {
-    if (!hasGetUserMedia()) return;
+  state = {
+    hasUserMedia: false,
+  };
 
+  componentDidMount() {
     Webcam.mountedInstances.push(this);
 
     if (!this.state.hasUserMedia && !Webcam.userMediaRequested) {
@@ -78,133 +60,164 @@ export default class Webcam extends Component {
         }
       }
       Webcam.userMediaRequested = false;
-      window.URL.revokeObjectURL(this.state.src);
+      this.videoElement.srcObject = null;
     }
   }
 
+  requestUserMedia() {
+    const sourceSelected = (audioSource, videoSource) => {
+      const { width, height } = this.props;
+
+      /* There is an inconsistency between Chrome v58 and Firefox
+      `exact` resolution constraint works in a different way to firefox. If the requested `exact` resolution is higher than the supported webcam resolution then Chrome will upscale.
+      However Firefox will trigger an OverConstraintError. I suspect Firefox is following the standard
+
+      In case a non exact resolution is requested, instead an `ideal` is, Firefox will handle all cases gracefully and prepare a resolution which is as close as possible to the requested one.
+      If the supported webcam resolution is higher than the requested one, then it downscales;
+      if it's lower, then it gives the highest available.
+      However, Chrome will just give the lowest resolution of the webcam, this seems like a bug.
+
+      Therefore, if one wants the ideal constraint functionality, the `exact` constraint works best on Chrome and the ideal one best on Firefox.
+
+      This lead us to use the `advanced` constraint to create a list of potential constraint fallbacks.
+      The weird thing is, that Chrome seems to work well with `ideal` if the constraint is defined as list element in `advanced`.
+      Which means that setting a list with multiple fallbacks is not necessary, but setting the one constaint in `advance` is.
+
+      The problem is that Firefox does not work with ideal well if advanced is used,
+      which means the ideal needs to go on the parent constraint, together with advanced for Chome.
+
+      ref: https://webrtchacks.com/getusermedia-resolutions-3/
+      ref: https://w3c.github.io/mediacapture-main/getusermedia.html#constrainable-interface
+      ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+      ref: https://github.com/webrtc/adapter/issues/408 They discuss the Chrome bug
+      ref: https://bugs.chromium.org/p/chromium/issues/detail?id=682887 the actual chrome bug
+       */
+      const constraints = {
+        video: {
+          sourceId: videoSource,
+          width,
+          height, // Necessary to get Firefox to work with ideal resolutions
+          advanced: [{ width, height }], // Necessary to get Chrome to work with ideal resolutions
+        },
+      };
+
+      if (this.props.audio) {
+        constraints.audio = {
+          sourceId: audioSource,
+        };
+      }
+
+      const logError = e => console.log("error", e, typeof e); // eslint-disable-line no-console
+
+      const onSuccess = stream => {
+        Webcam.mountedInstances.forEach(instance =>
+          instance.handleUserMedia(stream)
+        );
+      };
+
+      const onError = e => {
+        logError(e);
+        Webcam.mountedInstances.forEach(instance => instance.handleError(e));
+      };
+
+      getUserMedia(constraints)
+        .then(onSuccess)
+        .catch(onError);
+    };
+
+    if (this.props.audioSource && this.props.videoSource) {
+      sourceSelected(this.props.audioSource, this.props.videoSource);
+    } else if ("mediaDevices" in navigator) {
+      navigator.mediaDevices
+        .enumerateDevices()
+        .then(devices => {
+          let audioSource = null;
+          let videoSource = null;
+
+          devices.forEach(device => {
+            if (device.kind === "audio") {
+              audioSource = device.id;
+            } else if (device.kind === "video") {
+              videoSource = device.id;
+            }
+          });
+
+          sourceSelected(audioSource, videoSource);
+        })
+        .catch(error => {
+          console.log(`${error.name}: ${error.message}`); // eslint-disable-line no-console
+        });
+    }
+
+    Webcam.userMediaRequested = true;
+  }
+
+  handleError(error) {
+    this.setState({
+      hasUserMedia: false,
+    });
+    this.props.onFailure(error);
+  }
+
+  handleUserMedia(stream) {
+    this.stream = stream;
+    // Theoretically, this should be handled by setting the stream in state however
+    // HTMLMediaElement.srcObject can only be set by JS proprerty and not as a HTML attribute
+    // see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject
+    this.videoElement.srcObject = stream;
+    this.setState({
+      hasUserMedia: true,
+    });
+
+    this.props.onUserMedia();
+  }
+
   getScreenshot() {
-    if (!this.state.hasUserMedia) return null;
+    if (!this.state.hasUserMedia) {
+      return null;
+    }
 
     const canvas = this.getCanvas();
     return canvas.toDataURL(this.props.screenshotFormat);
   }
 
   getCanvas() {
-    if (!this.state.hasUserMedia) return null;
-
-    const video = findDOMNode(this);
-    if (!this.ctx) {
-      const canvas = document.createElement('canvas');
-      const aspectRatio = video.videoWidth / video.videoHeight;
-
-      canvas.width = video.clientWidth;
-      canvas.height = video.clientWidth / aspectRatio;
-
-      this.canvas = canvas;
-      this.ctx = canvas.getContext('2d');
+    if (!this.state.hasUserMedia) {
+      return null;
     }
 
-    const { ctx, canvas } = this;
+    const video = this.videoElement;
+
+    if (!this.canvas) {
+      this.canvas = document.createElement("canvas");
+    }
+
+    const { canvas } = this;
+
+    if (!this.ctx) {
+      this.ctx = canvas.getContext("2d");
+    }
+
+    const { ctx } = this;
+
+    // This is set every time in case the video element has resized
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+
     ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 
     return canvas;
-  }
-
-  requestUserMedia() {
-    navigator.getUserMedia = navigator.getUserMedia ||
-                          navigator.webkitGetUserMedia ||
-                          navigator.mozGetUserMedia ||
-                          navigator.msGetUserMedia;
-
-    const sourceSelected = (audioSource, videoSource) => {
-      const constraints = {
-        video: {
-          width: { ideal: this.props.width },
-          height: { ideal: this.props.height },
-          sourceId: videoSource,
-        },
-      };
-
-      if (this.props.audio) {
-        constraints.audio = {
-          optional: [{ sourceId: audioSource }],
-        };
-      }
-
-      navigator.getUserMedia(constraints, (stream) => {
-        Webcam.mountedInstances.forEach(instance => instance.handleUserMedia(null, stream));
-      }, (e) => {
-        Webcam.mountedInstances.forEach(instance => instance.handleUserMedia(e));
-      });
-    };
-
-    if (this.props.audioSource && this.props.videoSource) {
-      sourceSelected(this.props.audioSource, this.props.videoSource);
-    } else if ('mediaDevices' in navigator) {
-      navigator.mediaDevices.enumerateDevices().then((devices) => {
-        let audioSource = null;
-        let videoSource = null;
-
-        devices.forEach((device) => {
-          if (device.kind === 'audio') {
-            audioSource = device.id;
-          } else if (device.kind === 'video') {
-            videoSource = device.id;
-          }
-        });
-
-        sourceSelected(audioSource, videoSource);
-      })
-        .catch((error) => {
-          console.log(`${error.name}: ${error.message}`); // eslint-disable-line no-console
-        });
-    } else {
-      MediaStreamTrack.getSources((sources) => {
-        let audioSource = null;
-        let videoSource = null;
-
-        sources.forEach((source) => {
-          if (source.kind === 'audio') {
-            audioSource = source.id;
-          } else if (source.kind === 'video') {
-            videoSource = source.id;
-          }
-        });
-
-        sourceSelected(audioSource, videoSource);
-      });
-    }
-
-    Webcam.userMediaRequested = true;
-  }
-
-  handleUserMedia(error, stream) {
-    if (error) {
-      this.setState({
-        hasUserMedia: false,
-      });
-
-      return;
-    }
-
-    const src = window.URL.createObjectURL(stream);
-
-    this.stream = stream;
-    this.setState({
-      hasUserMedia: true,
-      src,
-    });
-
-    this.props.onUserMedia();
   }
 
   render() {
     return (
       <video
         autoPlay
+        ref={video => {
+          this.videoElement = video;
+        }}
         width={this.props.width}
         height={this.props.height}
-        src={this.state.src}
         muted={this.props.muted}
         className={this.props.className}
         style={this.props.style}
@@ -212,3 +225,17 @@ export default class Webcam extends Component {
     );
   }
 }
+
+Webcam.propTypes = {
+  audio: PropTypes.bool,
+  muted: PropTypes.bool,
+  onUserMedia: PropTypes.func,
+  onFailure: PropTypes.func,
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  screenshotFormat: PropTypes.oneOf(["image/webp", "image/png", "image/jpeg"]),
+  style: PropTypes.object,
+  className: PropTypes.string,
+  audioSource: PropTypes.string,
+  videoSource: PropTypes.string,
+};

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -18,6 +18,7 @@ export default class Webcam extends Component {
     onUserMedia: () => {},
     onFailure: () => {},
     className: "",
+    facingMode: "user",
   };
 
   static mountedInstances = [];
@@ -66,38 +67,13 @@ export default class Webcam extends Component {
 
   requestUserMedia() {
     const sourceSelected = (audioSource, videoSource) => {
-      const { width, height } = this.props;
-
-      /* There is an inconsistency between Chrome v58 and Firefox
-      `exact` resolution constraint works in a different way to firefox. If the requested `exact` resolution is higher than the supported webcam resolution then Chrome will upscale.
-      However Firefox will trigger an OverConstraintError. I suspect Firefox is following the standard
-
-      In case a non exact resolution is requested, instead an `ideal` is, Firefox will handle all cases gracefully and prepare a resolution which is as close as possible to the requested one.
-      If the supported webcam resolution is higher than the requested one, then it downscales;
-      if it's lower, then it gives the highest available.
-      However, Chrome will just give the lowest resolution of the webcam, this seems like a bug.
-
-      Therefore, if one wants the ideal constraint functionality, the `exact` constraint works best on Chrome and the ideal one best on Firefox.
-
-      This lead us to use the `advanced` constraint to create a list of potential constraint fallbacks.
-      The weird thing is, that Chrome seems to work well with `ideal` if the constraint is defined as list element in `advanced`.
-      Which means that setting a list with multiple fallbacks is not necessary, but setting the one constaint in `advance` is.
-
-      The problem is that Firefox does not work with ideal well if advanced is used,
-      which means the ideal needs to go on the parent constraint, together with advanced for Chome.
-
-      ref: https://webrtchacks.com/getusermedia-resolutions-3/
-      ref: https://w3c.github.io/mediacapture-main/getusermedia.html#constrainable-interface
-      ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
-      ref: https://github.com/webrtc/adapter/issues/408 They discuss the Chrome bug
-      ref: https://bugs.chromium.org/p/chromium/issues/detail?id=682887 the actual chrome bug
-       */
+      const { width, height, facingMode } = this.props;
       const constraints = {
         video: {
           sourceId: videoSource,
+          facingMode,
           width,
-          height, // Necessary to get Firefox to work with ideal resolutions
-          advanced: [{ width, height }], // Necessary to get Chrome to work with ideal resolutions
+          height,
         },
       };
 
@@ -213,6 +189,7 @@ export default class Webcam extends Component {
     return (
       <video
         autoPlay
+        playsInline
         ref={video => {
           this.videoElement = video;
         }}
@@ -231,9 +208,11 @@ Webcam.propTypes = {
   muted: PropTypes.bool,
   onUserMedia: PropTypes.func,
   onFailure: PropTypes.func,
+  // Safari iOS and some Android Chrome seem to ignore width and height
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   screenshotFormat: PropTypes.oneOf(["image/webp", "image/png", "image/jpeg"]),
+  facingMode: PropTypes.oneOf(["user", "environment", "left", "right"]),
   style: PropTypes.object,
   className: PropTypes.string,
   audioSource: PropTypes.string,

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -119,7 +119,9 @@ export default class Webcam extends Component {
     const sourceSelected = (audioSource, videoSource) => {
       const constraints = {
         video: {
-          optional: [{ sourceId: videoSource }],
+          width: { ideal: this.props.width },
+          height: { ideal: this.props.height },
+          sourceId: videoSource,
         },
       };
 

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -21,6 +21,22 @@ export default class Webcam extends Component {
     facingMode: "user",
   };
 
+  static propTypes = {
+    audio: PropTypes.bool,
+    muted: PropTypes.bool,
+    onUserMedia: PropTypes.func,
+    onFailure: PropTypes.func,
+    // Safari iOS and some Android Chrome seem to ignore width and height
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    screenshotFormat: PropTypes.oneOf(["image/webp", "image/png", "image/jpeg"]),
+    facingMode: PropTypes.oneOf(["user", "environment", "left", "right"]),
+    style: PropTypes.object,
+    className: PropTypes.string,
+    audioSource: PropTypes.string,
+    videoSource: PropTypes.string,
+  };
+
   static mountedInstances = [];
 
   static userMediaRequested = false;
@@ -202,19 +218,3 @@ export default class Webcam extends Component {
     );
   }
 }
-
-Webcam.propTypes = {
-  audio: PropTypes.bool,
-  muted: PropTypes.bool,
-  onUserMedia: PropTypes.func,
-  onFailure: PropTypes.func,
-  // Safari iOS and some Android Chrome seem to ignore width and height
-  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  screenshotFormat: PropTypes.oneOf(["image/webp", "image/png", "image/jpeg"]),
-  facingMode: PropTypes.oneOf(["user", "environment", "left", "right"]),
-  style: PropTypes.object,
-  className: PropTypes.string,
-  audioSource: PropTypes.string,
-  videoSource: PropTypes.string,
-};


### PR DESCRIPTION
Resolves #42
Merged in @onfido fork https://github.com/onfido/react-webcam.
Removed outdated API calls thereby also supported Safari 11.
Tidied code and removed deprecated `findDOMNode`.
Exporting the SupportsWebCam value to potentially alter rendering for unsupported clients.