### PR TITLE
Fix successive "empty" data URIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-webcam",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React webcam component",
   "main": "dist/react-webcam.js",
   "scripts": {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -86,13 +86,14 @@ export default class Webcam extends Component {
     if (!this.state.hasUserMedia) return null;
 
     const canvas = this.getCanvas();
-    return canvas.toDataURL(this.props.screenshotFormat);
+    return canvas && canvas.toDataURL(this.props.screenshotFormat);
   }
 
   getCanvas() {
-    if (!this.state.hasUserMedia) return null;
-
     const video = findDOMNode(this);
+
+    if (!this.state.hasUserMedia || !video.videoHeight) return null;
+
     if (!this.ctx) {
       const canvas = document.createElement('canvas');
       const aspectRatio = video.videoWidth / video.videoHeight;


### PR DESCRIPTION
Added patch for requesting screenshot before video has fully loaded - which caused successive empty dataURIs - for example: “data:,”