### PR TITLE
userMediaRequested set to false every time the component unmount

### DIFF
--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -137,6 +137,7 @@ export default class Webcam extends Component {
     const index = Webcam.mountedInstances.indexOf(this);
     Webcam.mountedInstances.splice(index, 1);
 
+    Webcam.userMediaRequested = false;
     if (Webcam.mountedInstances.length === 0 && this.state.hasUserMedia) {
       if (this.stream.stop) {
         this.stream.stop();
@@ -148,7 +149,6 @@ export default class Webcam extends Component {
           this.stream.getAudioTracks().map(track => track.stop());
         }
       }
-      Webcam.userMediaRequested = false;
       window.URL.revokeObjectURL(this.state.src);
     }
   }


### PR DESCRIPTION
Is some cases, for example when modal view with Webcam components are closed before the user can 'Allow' the browser to use the webcam, the component get unmounted but userMediaRequested=false is never called.
Moving that line before the if statement can solve this problem.