### PR TITLE
Added props to disable imageSmoothingEnabled in canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ class Component extends React.Component {
 | minScreenshotHeight | number   |              | min height of screenshot                                                                |
 | style               | object   |              | style prop passed to video element                                                      |
 | screenshotFormat    | string   | 'image/webp' | format of screenshot                                                                    |
+| imageSmoothing    | boolean   | true | pixel smoothing of the screenshot taken                                                                   |
 | onUserMedia         | function | noop         | callback for when component receives a media stream                                     |
 | onUserMediaError    | function | noop         | callback for when component can't receive a media stream with MediaStreamError param    |
 | screenshotQuality   | number   | 0.92         | quality of screenshot(0 to 1)                                                           |

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -75,6 +75,7 @@ export default class Webcam extends Component {
     audio: true,
     className: '',
     height: 480,
+    imageSmoothing: true,
     onUserMedia: () => {},
     onUserMediaError: () => {},
     screenshotFormat: 'image/webp',
@@ -100,6 +101,7 @@ export default class Webcam extends Component {
     minScreenshotHeight: PropTypes.number,
     audioConstraints: audioConstraintType,
     videoConstraints: videoConstraintType,
+    imageSmoothing: PropTypes.bool,
   };
 
   static mountedInstances = [];
@@ -186,6 +188,7 @@ export default class Webcam extends Component {
     }
 
     const { ctx, canvas } = this;
+    ctx.imageSmoothingEnabled = this.props.imageSmoothing;
     ctx.drawImage(this.video, 0, 0, canvas.width, canvas.height);
 
     return canvas;


### PR DESCRIPTION
 Added props to disable imageSmoothingEnabled in canvas as it's adding a slight blur to screenshots taken (https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled)