### PR TITLE
add support for old browsers

### DIFF
--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 function hasGetUserMedia() {
   return !!(
-    (navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
-    || navigator.getUserMedia 
+    (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) 
     || navigator.webkitGetUserMedia
     || navigator.mozGetUserMedia
     || navigator.msGetUserMedia
+    || navigator.getUserMedia
   );
 }
 
@@ -206,11 +206,11 @@ export default class Webcam extends Component {
   requestUserMedia() {
     const { props } = this;
 
-    navigator.getUserMedia = navigator.mediaDevices.getUserMedia
-      || navigator.getUserMedia 
+    navigator.getUserMedia = navigator.mediaDevices.getUserMedia 
       || navigator.webkitGetUserMedia
       || navigator.mozGetUserMedia
-      || navigator.msGetUserMedia;
+      || navigator.msGetUserMedia
+      || navigator.getUserMedia;
 
     const sourceSelected = (audioConstraints, videoConstraints) => {
       const constraints = {

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 function hasGetUserMedia() {
   return !!(
-    (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) 
+    (navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
     || navigator.webkitGetUserMedia
     || navigator.mozGetUserMedia
     || navigator.msGetUserMedia
@@ -206,7 +206,7 @@ export default class Webcam extends Component {
   requestUserMedia() {
     const { props } = this;
 
-    navigator.getUserMedia = navigator.mediaDevices.getUserMedia 
+    navigator.getUserMedia = navigator.mediaDevices.getUserMedia
       || navigator.webkitGetUserMedia
       || navigator.mozGetUserMedia
       || navigator.msGetUserMedia

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 function hasGetUserMedia() {
   return !!(
     (navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
+    || navigator.getUserMedia 
     || navigator.webkitGetUserMedia
     || navigator.mozGetUserMedia
     || navigator.msGetUserMedia
@@ -206,6 +207,7 @@ export default class Webcam extends Component {
     const { props } = this;
 
     navigator.getUserMedia = navigator.mediaDevices.getUserMedia
+      || navigator.getUserMedia 
       || navigator.webkitGetUserMedia
       || navigator.mozGetUserMedia
       || navigator.msGetUserMedia;
@@ -219,7 +221,7 @@ export default class Webcam extends Component {
         constraints.audio = audioConstraints || true;
       }
 
-      navigator.mediaDevices
+      navigator
         .getUserMedia(constraints)
         .then((stream) => {
           Webcam.mountedInstances.forEach(instance => instance.handleUserMedia(null, stream));


### PR DESCRIPTION
add support for old  browsers where navigator.mediaDevices.getUserMedia is not available but navigator.getUserMedia is available.