### PR TITLE
Mirrored camera option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The props here are specific to this component but one can pass any prop to the u
 | audio               | boolean  | true         | enable/disable audio                                                                    |
 | audioConstraints    | object   |              | MediaStreamConstraint(s) for the audio                                                  |
 | imageSmoothing      | boolean  | true         | pixel smoothing of the screenshot taken                                                 å|
+| mirrored            | boolean  | false        | show camera preview and get the screenshot mirrored                                     |
 | minScreenshotHeight | number   |              | min height of screenshot                                                                |
 | minScreenshotWidth  | number   |              | min width of screenshot                                                                 |
 | onUserMedia         | function | noop         | callback for when component receives a media stream                                     |

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -13,6 +13,7 @@ interface WebcamProps {
   audio: boolean;
   audioConstraints?: MediaStreamConstraints["audio"];
   imageSmoothing: boolean;
+  mirrored?: boolean;
   minScreenshotHeight?: number;
   minScreenshotWidth?: number;
   onUserMedia: () => void;
@@ -20,7 +21,6 @@ interface WebcamProps {
   screenshotFormat: "image/webp" | "image/png" | "image/jpeg";
   screenshotQuality: number;
   videoConstraints?: MediaStreamConstraints["video"];
-  mirrored?: boolean;
 }
 
 interface WebcamState {
@@ -34,9 +34,9 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
     imageSmoothing: true,
     onUserMedia: () => {},
     onUserMediaError: () => {},
+    mirrored: false,
     screenshotFormat: "image/webp",
     screenshotQuality: 0.92,
-    mirrored: false
   };
 
   static mountedInstances: Webcam[] = [];

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -20,6 +20,7 @@ interface WebcamProps {
   screenshotFormat: "image/webp" | "image/png" | "image/jpeg";
   screenshotQuality: number;
   videoConstraints?: MediaStreamConstraints["video"];
+  mirrored?: boolean;
 }
 
 interface WebcamState {
@@ -34,7 +35,8 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
     onUserMedia: () => {},
     onUserMediaError: () => {},
     screenshotFormat: "image/webp",
-    screenshotQuality: 0.92
+    screenshotQuality: 0.92,
+    mirrored: false
   };
 
   static mountedInstances: Webcam[] = [];
@@ -146,6 +148,13 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
     const { ctx, canvas } = this;
 
     if (ctx) {
+      if (props.mirrored) {
+        ctx.translate(canvas.width, 0);
+        ctx.scale(-1, 1);
+      } else {
+        ctx.translate(0, 0);
+        ctx.scale(1, 1);
+      }
       ctx.imageSmoothingEnabled = props.imageSmoothing;
       ctx.drawImage(this.video, 0, 0, canvas.width, canvas.height);
     }
@@ -283,8 +292,12 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
       audioConstraints,
       videoConstraints,
       imageSmoothing,
+      mirrored,
+      style,
       ...rest
     } = props;
+
+    const videoStyle = mirrored ? { ...style, transform: "scaleX(-1)" } : style;
 
     return (
       <video
@@ -295,6 +308,7 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
         ref={ref => {
           this.video = ref;
         }}
+        style={videoStyle}
         {...rest}
       />
     );

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -32,9 +32,9 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
   static defaultProps = {
     audio: true,
     imageSmoothing: true,
+    mirrored: false,
     onUserMedia: () => {},
     onUserMediaError: () => {},
-    mirrored: false,
     screenshotFormat: "image/webp",
     screenshotQuality: 0.92,
   };

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -293,11 +293,11 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
       videoConstraints,
       imageSmoothing,
       mirrored,
-      style,
+      style = {},
       ...rest
     } = props;
 
-    const videoStyle = mirrored ? { ...style, transform: "scaleX(-1)" } : style;
+    const videoStyle = mirrored ? { ...style, transform: `${style.transform || ""} scaleX(-1)` } : style;
 
     return (
       <video


### PR DESCRIPTION
# Description
If a mirrored option is needed, the video or container needs to be flip but the `getScreenshot` is returning a not mirrored image so the resulted image will always need an extra CSS to flip the image.

It also makes more difficult working with overlapping shapes on top of the image because you need to aware that it will be flip so -10px means +10px.

# Solution
Add a mirrored prop that will display the video tag flip and modify the `getScreenshot` to return the image mirrored.