### PR TITLE
Cleanup 'getUserMedia' polyfill

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -1,12 +1,42 @@
 import * as React from "react";
 
+// polyfill based on https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+(function polyfillGetUserMedia() {
+  // Older browsers might not implement mediaDevices at all, so we set an empty object first
+  if (navigator.mediaDevices === undefined) {
+    (navigator as any).mediaDevices = {};
+  }
+
+  // Some browsers partially implement mediaDevices. We can't just assign an object
+  // with getUserMedia as it would overwrite existing properties.
+  // Here, we will just add the getUserMedia property if it's missing.
+  if (navigator.mediaDevices.getUserMedia === undefined) {
+    navigator.mediaDevices.getUserMedia = function(constraints) {
+      // First get ahold of the legacy getUserMedia, if present
+      const getUserMedia =
+        navigator.getUserMedia ||
+        navigator.webkitGetUserMedia ||
+        navigator.mozGetUserMedia ||
+        navigator.msGetUserMedia;
+
+      // Some browsers just don't implement it - return a rejected promise with an error
+      // to keep a consistent interface
+      if (!getUserMedia) {
+        return Promise.reject(
+          new Error("getUserMedia is not implemented in this browser")
+        );
+      }
+
+      // Otherwise, wrap the call to the old navigator.getUserMedia with a Promise
+      return new Promise(function(resolve, reject) {
+        getUserMedia.call(navigator, constraints, resolve, reject);
+      });
+    };
+  }
+})();
+
 function hasGetUserMedia() {
-  return !!(
-    (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) ||
-    navigator.webkitGetUserMedia ||
-    navigator.mozGetUserMedia ||
-    navigator.msGetUserMedia
-  );
+  return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
 }
 
 interface WebcamProps {
@@ -175,12 +205,6 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
 
   requestUserMedia() {
     const { props } = this;
-
-    navigator.getUserMedia =
-      navigator.mediaDevices.getUserMedia ||
-      navigator.webkitGetUserMedia ||
-      navigator.mozGetUserMedia ||
-      navigator.msGetUserMedia;
 
     const sourceSelected = (audioConstraints, videoConstraints) => {
       const constraints: MediaStreamConstraints = {


### PR DESCRIPTION
The old polyfill got broken in commit ea3ed206 (navigator.getUserMedia
got replaced with navigator.mediaDevices.getUserMedia).

This new polyfill modifies the global navigator object unconditionally
when required and react-webcam is imported (the old one only changed
navigator.getUserMedia when media got requested by react-webcam).

If we decide to no longer polyfill for older browser, we can simply drop
one self containing method.