### PR TITLE
Add new property to force screenshot with same size as video source

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,20 @@ const WebcamComponent = () => <Webcam />;
 
 The props here are specific to this component but one can pass any prop to the underlying video tag eg `className` or `style`
 
-| prop                | type     | default      | notes                                                                                   |
-| -----------------   | -------- | ------------ | --------------------------------------------------------------------------------------- |
-| audio               | boolean  | true         | enable/disable audio                                                                    |
-| audioConstraints    | object   |              | MediaStreamConstraint(s) for the audio                                                  |
-| imageSmoothing      | boolean  | true         | pixel smoothing of the screenshot taken                                                 å|
-| mirrored            | boolean  | false        | show camera preview and get the screenshot mirrored                                     |
-| minScreenshotHeight | number   |              | min height of screenshot                                                                |
-| minScreenshotWidth  | number   |              | min width of screenshot                                                                 |
-| onUserMedia         | function | noop         | callback for when component receives a media stream                                     |
-| onUserMediaError    | function | noop         | callback for when component can't receive a media stream with MediaStreamError param    |
-| screenshotFormat    | string   | 'image/webp' | format of screenshot                                                                    |
-| screenshotQuality   | number   | 0.92         | quality of screenshot(0 to 1)                                                           |
-| videoConstraints    | object   |              | MediaStreamConstraints(s) for the video                                                 |
+| prop                      | type     | default      | notes                                                                                   |
+| ------------------------- | -------- | ------------ | --------------------------------------------------------------------------------------- |
+| audio                     | boolean  | true         | enable/disable audio                                                                    |
+| audioConstraints          | object   |              | MediaStreamConstraint(s) for the audio                                                  |
+| forceScreenshotSourceSize | boolean  | false        | uses size of underlying source video stream (and thus ignores other size related props) |
+| imageSmoothing            | boolean  | true         | pixel smoothing of the screenshot taken                                                 |
+| mirrored                  | boolean  | false        | show camera preview and get the screenshot mirrored                                     |
+| minScreenshotHeight       | number   |              | min height of screenshot                                                                |
+| minScreenshotWidth        | number   |              | min width of screenshot                                                                 |
+| onUserMedia               | function | noop         | callback for when component receives a media stream                                     |
+| onUserMediaError          | function | noop         | callback for when component can't receive a media stream with MediaStreamError param    |
+| screenshotFormat          | string   | 'image/webp' | format of screenshot                                                                    |
+| screenshotQuality         | number   | 0.92         | quality of screenshot(0 to 1)                                                           |
+| videoConstraints          | object   |              | MediaStreamConstraints(s) for the video                                                 |
 
 ### Methods
 

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -43,7 +43,7 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
 
   static userMediaRequested = false;
 
-  canvas: HTMLCanvasElement;
+  canvas: HTMLCanvasElement | null = null;
 
   ctx: CanvasRenderingContext2D | null = null;
 
@@ -83,12 +83,25 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
       return;
     }
 
-    if (
+    const audioConstraintsChanged =
       JSON.stringify(nextProps.audioConstraints) !==
-      JSON.stringify(props.audioConstraints) ||
+      JSON.stringify(props.audioConstraints);
+    const videoConstraintsChanged =
       JSON.stringify(nextProps.videoConstraints) !==
-      JSON.stringify(props.videoConstraints)
+      JSON.stringify(props.videoConstraints);
+    const minScreenshotWidthChanged =
+      nextProps.minScreenshotWidth !== props.minScreenshotWidth;
+    const minScreenshotHeightChanged =
+      nextProps.minScreenshotHeight !== props.minScreenshotHeight;
+    if (
+      videoConstraintsChanged ||
+      minScreenshotWidthChanged ||
+      minScreenshotHeightChanged
     ) {
+      this.canvas = null;
+      this.ctx = null;
+    }
+    if (audioConstraintsChanged || videoConstraintsChanged) {
       this.requestUserMedia();
     }
   }
@@ -158,7 +171,7 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
 
     const { ctx, canvas } = this;
 
-    if (ctx) {
+    if (ctx && canvas) {
       // mirror the screenshot
       if (props.mirrored) {
         ctx.translate(canvas.width, 0);

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -12,6 +12,7 @@ function hasGetUserMedia() {
 interface WebcamProps {
   audio: boolean;
   audioConstraints?: MediaStreamConstraints["audio"];
+  forceScreenshotSourceSize?: boolean;
   imageSmoothing: boolean;
   mirrored?: boolean;
   minScreenshotHeight?: number;
@@ -31,6 +32,7 @@ interface WebcamState {
 export default class Webcam extends React.Component<WebcamProps & React.HTMLAttributes<HTMLVideoElement>, WebcamState> {
   static defaultProps = {
     audio: true,
+    forceScreenshotSourceSize: false,
     imageSmoothing: true,
     mirrored: false,
     onUserMedia: () => { },
@@ -148,25 +150,27 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
     if (!state.hasUserMedia || !this.video.videoHeight) return null;
 
     if (!this.ctx) {
-      const canvas = document.createElement("canvas");
-      const aspectRatio = this.video.videoWidth / this.video.videoHeight;
+      let canvasWidth = this.video.videoWidth;
+      let canvasHeight = this.video.videoHeight;
+      if (!this.props.forceScreenshotSourceSize) {
+        const aspectRatio = canvasWidth / canvasHeight;
 
-      let canvasWidth = props.minScreenshotWidth || this.video.clientWidth;
-      let canvasHeight = canvasWidth / aspectRatio;
+        canvasWidth = props.minScreenshotWidth || this.video.clientWidth;
+        canvasHeight = canvasWidth / aspectRatio;
 
-      if (
-        props.minScreenshotHeight &&
-        canvasHeight < props.minScreenshotHeight
-      ) {
-        canvasHeight = props.minScreenshotHeight;
-        canvasWidth = canvasHeight * aspectRatio;
+        if (
+          props.minScreenshotHeight &&
+          canvasHeight < props.minScreenshotHeight
+        ) {
+          canvasHeight = props.minScreenshotHeight;
+          canvasWidth = canvasHeight * aspectRatio;
+        }
       }
 
-      canvas.width = canvasWidth;
-      canvas.height = canvasHeight;
-
-      this.canvas = canvas;
-      this.ctx = canvas.getContext("2d");
+      this.canvas = document.createElement("canvas");
+      this.canvas.width = canvasWidth;
+      this.canvas.height = canvasHeight;
+      this.ctx = this.canvas.getContext("2d");
     }
 
     const { ctx, canvas } = this;
@@ -312,6 +316,7 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
 
     const {
       audio,
+      forceScreenshotSourceSize,
       onUserMedia,
       onUserMediaError,
       screenshotFormat,


### PR DESCRIPTION
This new property is useful when you request a larger video source via e.g. `videoConstraints={{ width: 1080}}`, but display it in a smaller preview place. When enabled, the screenshot has the full size of the source video stream, which also means that no resizing is necessary when drawing it to the canvas.

Default behavior does not change.
