### PR TITLE
Remove loop in requestUserMedia for mounted devices

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -247,14 +247,10 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
       navigator.mediaDevices
         .getUserMedia(constraints)
         .then(stream => {
-          Webcam.mountedInstances.forEach(instance =>
-            instance.handleUserMedia(null, stream)
-          );
+          this.handleUserMedia(null, stream);
         })
         .catch(e => {
-          Webcam.mountedInstances.forEach(instance =>
-            instance.handleUserMedia(e)
-          );
+          this.handleUserMedia(e);
         });
     };
 


### PR DESCRIPTION
See issue https://github.com/mozmorris/react-webcam/issues/185
I have three webcams connected to my machine. When I change the stream source for one, it changes all video elements on the page. 
Before change: 
![react-webcam-before](https://user-images.githubusercontent.com/7564876/72238484-75c4e200-35a3-11ea-9601-ed46958d4e54.png)
After this commit, each video element is independent and when I change the steam source for one, it does not update all video elements on the page anymore.
![react-webcam-after](https://user-images.githubusercontent.com/7564876/72238496-7f4e4a00-35a3-11ea-9363-f9f4b4284cc2.png)

