### PR TITLE
Update Typescript defintion to include HTMLVideoElement props

### DIFF
--- a/src/__tests__/__snapshots__/react-webcam.tsx.snap
+++ b/src/__tests__/__snapshots__/react-webcam.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders correctly 1`] = `
 <video
   autoPlay={true}
   className="react-webcam"
+  height={1000}
   muted={false}
   playsInline={true}
   style={
@@ -11,5 +12,6 @@ exports[`renders correctly 1`] = `
       "transform": "rotate(180deg)",
     }
   }
+  width={1000}
 />
 `;

--- a/src/__tests__/react-webcam.tsx
+++ b/src/__tests__/react-webcam.tsx
@@ -25,6 +25,8 @@ it('renders correctly', () => {
           height: 120,
           frameRate: 15
         }}
+        height={1000}
+        width={1000}
       />
     )
     .toJSON();

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -43,7 +43,7 @@ function hasGetUserMedia() {
   return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
 }
 
-export interface WebcamProps {
+export interface WebcamProps extends React.HTMLProps<HTMLVideoElement> {
   audio: boolean;
   audioConstraints?: MediaStreamConstraints["audio"];
   forceScreenshotSourceSize: boolean;

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -63,7 +63,7 @@ interface WebcamState {
   src?: string;
 }
 
-export default class Webcam extends React.Component<WebcamProps & React.HTMLAttributes<HTMLVideoElement>, WebcamState> {
+export default class Webcam extends React.Component<WebcamProps, WebcamState> {
   static defaultProps = {
     audio: true,
     forceScreenshotSourceSize: false,


### PR DESCRIPTION
As the component passes props down to the `<video>` tag, this allows the typescript definition to include the HTMLVideoElement props as part of the component.

I've also updated the test to show this working, as height/width are props on the `<video>` tag, not on the Webcam component