### PR TITLE
Prevent resource leaks on constraint changes

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -132,11 +132,16 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
       this.ctx = null;
     }
     if (audioConstraintsChanged || videoConstraintsChanged) {
+      this.stopAndCleanup();
       this.requestUserMedia();
     }
   }
 
   componentWillUnmount() {
+    this.stopAndCleanup();
+  }
+
+  private stopAndCleanup() {
     const { state } = this;
 
     if (state.hasUserMedia) {


### PR DESCRIPTION
When you change constrains via props, a new #getUserMedia()
call got issued which leads in a new stream. The old stream
got not cleaned up and the tracks got not stopped. Without
stopping tracks, I was able to just get a black input on a
Huawei P30 device after switching between the different
environment cameras. Not revoking ObjectURLs leads in
memory leaks.

Use as testcase (device with multiple cameras required; alternative: add a "Dummy" button with a deviceId=dummy (which of course does not exist) and change `videoConstraints` to `{{ deviceId: {exact: deviceId} }}`): https://codepen.io/mozmorris/pen/KKwdOPO?editors=0010