### PR TITLE
Call props.onUserMediaError when !hasGetUserMedia

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -59,8 +59,11 @@ export default class Webcam extends React.Component<WebcamProps & React.HTMLAttr
   }
 
   componentDidMount() {
-    if (!hasGetUserMedia()) return;
-
+    if (!hasGetUserMedia()) {
+      this.props.onUserMediaError('There is not userMedia available');
+      return;
+    }
+  
     const { state } = this;
 
     Webcam.mountedInstances.push(this);


### PR DESCRIPTION
When there is not getUserMedia available, like opening a website on iOS Facebook Messenger Webview there is not getUserMedia, so it does not open the video but the error is not thrown in order to give some feedback to the user.