### PR TITLE
Add stream argument to onUserMedia callback

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -51,7 +51,7 @@ export interface WebcamProps extends React.HTMLProps<HTMLVideoElement> {
   mirrored: boolean;
   minScreenshotHeight?: number;
   minScreenshotWidth?: number;
-  onUserMedia: () => void;
+  onUserMedia: (stream: MediaStream) => void;
   onUserMediaError: (error: string) => void;
   screenshotFormat: "image/webp" | "image/png" | "image/jpeg";
   screenshotQuality: number;
@@ -328,7 +328,7 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
       });
     }
 
-    props.onUserMedia();
+    props.onUserMedia(stream);
   }
 
   render() {


### PR DESCRIPTION
Hello,

I want to create a component to check webcam and microphpne permissions for an application and I need to check microphone volume too. I'll be able to do it with the `stream` but this library make it private. So I just add it to the `onUserMedia` callback.

Here is an example : 

```js
import React, { useCallback, useState } from 'react'
import Webcam from 'react-webcam'

const videoConstraints = {
  facingMode: 'user'
}

const listenMicrophoneLevel = (stream, cb) => {
  const aduio = new AudioContext();
  const analyser = aduio.createAnalyser();
  const microphone = aduio.createMediaStreamSource(stream);
  const processor = aduio.createScriptProcessor(2048, 1, 1);
  analyser.smoothingTimeConstant = 0.8;
  analyser.fftSize = 1024;
  microphone.connect(analyser);
  analyser.connect(processor);
  processor.connect(aduio.destination);
  processor.onaudioprocess = () => {
    let data = new Uint8Array(analyser.frequencyBinCount);
    analyser.getByteFrequencyData(data);
    // return 0-100+, over 100, consider the sound as too loud
    cb(Math.round(data.reduce((acc, curr) => acc + curr, 0) / data.length));
  }
}

const Permissions = ({ ...props }) => {
  const [micLevel, setMicLevel] = useState(0)
  const handleUserMedia = useCallback((stream) => {
    listenMicrophoneLevel(stream, setMicLevel)
  }, [])

  console.log(micLevel)

  return (
      <Webcam
        audio={true}
        videoConstraints={videoConstraints}
        onUserMedia={handleUserMedia}
      />
  )
}

export default Permissions
```