### PR TITLE
Add missing usage of width/height in getScreenshot

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -220,7 +220,7 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
       }
 
       ctx.imageSmoothingEnabled = props.imageSmoothing;
-      ctx.drawImage(this.video, 0, 0, canvas.width, canvas.height);
+      ctx.drawImage(this.video, 0, 0, screenshotDimensions?.width || canvas.width, screenshotDimensions?.height || canvas.height);
 
       // invert mirroring
       if (props.mirrored) {


### PR DESCRIPTION
My fault, I realized that this only took custom dimension screenshots when the canvas is initialized. It never took custom dimension screenshots afterwards. I adjusted it here.