### PR TITLE
fix: Stream not cleaned when getUserMedia is multiple called

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -84,6 +84,8 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
 
   private ctx: CanvasRenderingContext2D | null = null;
 
+  private requestUserMediaId = 0;
+
   private unmounted = false;
 
   stream: MediaStream | null;
@@ -255,10 +257,13 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
           typeof audioConstraints !== "undefined" ? audioConstraints : true;
       }
 
+      this.requestUserMediaId++
+      const myRequestUserMediaId = this.requestUserMediaId
+
       navigator.mediaDevices
         .getUserMedia(constraints)
         .then(stream => {
-          if (this.unmounted) {
+          if (this.unmounted || myRequestUserMediaId !== this.requestUserMediaId) {
             Webcam.stopMediaStream(stream);
           } else {
             this.handleUserMedia(null, stream);


### PR DESCRIPTION
If getUserMedia is multiple called before it resolves, use the latest stream and did not clean the unused streams.

ex: 
- getUserMedia is too slow and change constraints before getting the stream
- change constraints quickly