### PR TITLE
fix: #272 onUserMediaError parameter type

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -57,7 +57,7 @@ export type WebcamProps = Omit<React.HTMLProps<HTMLVideoElement>, "ref"> & {
   minScreenshotHeight?: number;
   minScreenshotWidth?: number;
   onUserMedia: (stream: MediaStream) => void;
-  onUserMediaError: (error: string) => void;
+  onUserMediaError: (error: DOMException) => void;
   screenshotFormat: "image/webp" | "image/png" | "image/jpeg";
   screenshotQuality: number;
   videoConstraints?: MediaStreamConstraints["video"];

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -57,7 +57,7 @@ export type WebcamProps = Omit<React.HTMLProps<HTMLVideoElement>, "ref"> & {
   minScreenshotHeight?: number;
   minScreenshotWidth?: number;
   onUserMedia: (stream: MediaStream) => void;
-  onUserMediaError: (error: DOMException) => void;
+  onUserMediaError: (error: string | DOMException) => void;
   screenshotFormat: "image/webp" | "image/png" | "image/jpeg";
   screenshotQuality: number;
   videoConstraints?: MediaStreamConstraints["video"];


### PR DESCRIPTION
Issue: #272

Changed the parameter type. I was getting a `DOMException` back from the example code shown in #272, not a `string`.