### PR TITLE
Fix Android 11 freezing issues

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -152,8 +152,14 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
   private static stopMediaStream(stream: MediaStream | null) {
     if (stream) {
       if (stream.getVideoTracks && stream.getAudioTracks) {
-        stream.getVideoTracks().map(track => track.stop());
-        stream.getAudioTracks().map(track => track.stop());
+        stream.getVideoTracks().map(track => {
+          stream.removeTrack(track);
+          track.stop();
+        });
+        stream.getAudioTracks().map(track => {
+          stream.removeTrack(track);
+          track.stop()
+        });
       } else {
         ((stream as unknown) as MediaStreamTrack).stop();
       }


### PR DESCRIPTION
Following this thread https://github.com/twilio/twilio-video-app-react/issues/355

Calling the `stream.removeTrack` before `.stop()` fixes the freezing issues in Android 11.