### PR TITLE
fix: properly set muted on video based on props.audio

### DIFF
--- a/src/__tests__/__snapshots__/react-webcam.test.tsx.snap
+++ b/src/__tests__/__snapshots__/react-webcam.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders correctly 1`] = `
   autoPlay={true}
   className="react-webcam"
   height={1000}
-  muted={false}
+  muted={true}
   playsInline={true}
   style={
     Object {

--- a/src/__tests__/react-webcam.test.tsx
+++ b/src/__tests__/react-webcam.test.tsx
@@ -29,7 +29,37 @@ it('renders correctly', () => {
         width={1000}
       />
     )
-    .toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(tree.toJSON()).toMatchSnapshot();
 });
+
+it('sets <video/> muted to false when props.audio is true', () => {
+  const tree = renderer
+    .create(
+      <Webcam
+        audio={true}
+        audioConstraints={{
+          sampleSize: 8,
+          echoCancellation: true
+        }}
+        className="react-webcam"
+        imageSmoothing={false}
+        minScreenshotHeight={1000}
+        minScreenshotWidth={1000}
+        onUserMedia={() => {}}
+        onUserMediaError={() => {}}
+        screenshotFormat="image/png"
+        screenshotQuality={1}
+        style={{transform: 'rotate(180deg)'}}
+        videoConstraints={{
+          width: 160,
+          height: 120,
+          frameRate: 15
+        }}
+        height={1000}
+        width={1000}
+      />
+    )
+
+  expect(tree.root.findByType('video').props.muted).toBe(false)
+})

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -382,7 +382,7 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
       <video
         autoPlay
         src={state.src}
-        muted={audio}
+        muted={!audio}
         playsInline
         ref={ref => {
           this.video = ref;


### PR DESCRIPTION
Closes #182.

Initial pass on this. Not sure what your philosophy is on writing tests;
I made mine check the actual node property instead of a snapshot to be
more explicit.