### PR TITLE
Stram could not be acquired

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -106,6 +106,7 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
 
   componentDidMount() {
     const { state, props } = this;
+    this.unmounted = false;
 
     if (!hasGetUserMedia()) {
       props.onUserMediaError("getUserMedia not supported");


### PR DESCRIPTION
We only set the `unmounted` attribute value when unmounted, but not when mounted.