### PR TITLE
adjust canvas dimensions according to parameters of getscreenshot function

### DIFF
--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -238,6 +238,11 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
     const { ctx, canvas } = this;
 
     if (ctx && canvas) {
+
+      // adjust the height and width of the canvas to the given dimensions
+      canvas.width = screenshotDimensions?.width ||  canvas.width;
+      canvas.height = screenshotDimensions?.height || canvas.height;
+
       // mirror the screenshot
       if (props.mirrored) {
         ctx.translate(canvas.width, 0);


### PR DESCRIPTION
When the getScreenshot function gets called the first time, it creates a canvas object with given dimensions (if provided). From the next time onwards, it uses the same canvas to draw images. So, if someone passes different parameters the next time, it still uses the canvas built using parameters provided in the first time.

If we resize the canvas before drawing the image, it would resolve this issue.