### PR TITLE
Support prop to disable Picture-in-Picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ const WebcamComponent = () => <Webcam />;
 The props here are specific to this component but one can pass any prop to the underlying video tag eg `className`, `style`, `muted`, etc
 
 | prop                      | type     | default      | notes                                                                                   |
-| ------------------------- | -------- | ------------ | --------------------------------------------------------------------------------------- |
+|---------------------------|----------|--------------|-----------------------------------------------------------------------------------------|
 | audio                     | boolean  | false        | enable/disable audio                                                                    |
 | audioConstraints          | object   |              | MediaStreamConstraint(s) for the audio                                                  |
+| disablePictureInPicture   | boolean  | true         | disable Picture-in-Picture                                                              |
 | forceScreenshotSourceSize | boolean  | false        | uses size of underlying source video stream (and thus ignores other size related props) |
 | imageSmoothing            | boolean  | true         | pixel smoothing of the screenshot taken                                                 |
 | mirrored                  | boolean  | false        | show camera preview and get the screenshot mirrored                                     |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The props here are specific to this component but one can pass any prop to the u
 |---------------------------|----------|--------------|-----------------------------------------------------------------------------------------|
 | audio                     | boolean  | false        | enable/disable audio                                                                    |
 | audioConstraints          | object   |              | MediaStreamConstraint(s) for the audio                                                  |
-| disablePictureInPicture   | boolean  | true         | disable Picture-in-Picture                                                              |
+| disablePictureInPicture   | boolean  | false        | disable Picture-in-Picture                                                              |
 | forceScreenshotSourceSize | boolean  | false        | uses size of underlying source video stream (and thus ignores other size related props) |
 | imageSmoothing            | boolean  | true         | pixel smoothing of the screenshot taken                                                 |
 | mirrored                  | boolean  | false        | show camera preview and get the screenshot mirrored                                     |

--- a/src/__tests__/__snapshots__/react-webcam.test.tsx.snap
+++ b/src/__tests__/__snapshots__/react-webcam.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders correctly 1`] = `
 <video
   autoPlay={true}
   className="react-webcam"
+  disablePictureInPicture={false}
   height={1000}
   muted={true}
   playsInline={true}

--- a/src/__tests__/react-webcam.test.tsx
+++ b/src/__tests__/react-webcam.test.tsx
@@ -63,3 +63,35 @@ it('sets <video/> muted to false when props.audio is true', () => {
 
   expect(tree.root.findByType('video').props.muted).toBe(false)
 })
+
+it('sets <video/> disablePictureInPicture to true when props.disablePictureInPicture is true', () => {
+  const tree = renderer
+    .create(
+      <Webcam
+        audio={false}
+        audioConstraints={{
+          sampleSize: 8,
+          echoCancellation: true
+        }}
+        className="react-webcam"
+        disablePictureInPicture={true}
+        imageSmoothing={false}
+        minScreenshotHeight={1000}
+        minScreenshotWidth={1000}
+        onUserMedia={() => {}}
+        onUserMediaError={() => {}}
+        screenshotFormat="image/png"
+        screenshotQuality={1}
+        style={{transform: 'rotate(180deg)'}}
+        videoConstraints={{
+          width: 160,
+          height: 120,
+          frameRate: 15
+        }}
+        height={1000}
+        width={1000}
+      />
+    )
+
+  expect(tree.root.findByType('video').props.disablePictureInPicture).toBe(true)
+})

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -55,6 +55,7 @@ interface ChildrenProps {
 export type WebcamProps = Omit<React.HTMLProps<HTMLVideoElement>, "ref"> & {
   audio: boolean;
   audioConstraints?: MediaStreamConstraints["audio"];
+  disablePictureInPicture: boolean;
   forceScreenshotSourceSize: boolean;
   imageSmoothing: boolean;
   mirrored: boolean;
@@ -76,6 +77,7 @@ interface WebcamState {
 export default class Webcam extends React.Component<WebcamProps, WebcamState> {
   static defaultProps = {
     audio: false,
+    disablePictureInPicture: false,
     forceScreenshotSourceSize: false,
     imageSmoothing: true,
     mirrored: false,
@@ -382,6 +384,7 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
     const {
       audio,
       forceScreenshotSourceSize,
+      disablePictureInPicture,
       onUserMedia,
       onUserMediaError,
       screenshotFormat,
@@ -407,6 +410,7 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
       <>
         <video
           autoPlay
+          disablePictureInPicture={disablePictureInPicture}
           src={state.src}
           muted={!audio}
           playsInline


### PR DESCRIPTION
This commit adds a new prop to the webcam component `disablePictureInPicture` which
as the name suggests, should disable this feature for any browser that supports it.

Defaults to false.

more context on the disablePictureInPicture property: https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/disablePictureInPicture
