### PR TITLE
Add method to get screenshot as a `Blob` instead of base64-encoded string

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ You may also pass in an optional `dimensions` object:
 getScreenshot({width: 1920, height: 1080});
 ```
 
+`getScreenshotBlob` - Returns a Promise that resolves to a Blob of the current webcam image. This is more efficient than base64 encoding when uploading to a server or processing large images. Example:
+
+```jsx
+const capture = async () => {
+  try {
+    const blob = await webcamRef.current.getScreenshotBlob({width: 1920, height: 1080});
+    if (blob) {
+      // Upload to a server
+      const formData = new FormData();
+      formData.append('image', blob);
+      await fetch('/upload', { method: 'POST', body: formData });
+      
+      // Or create an object URL for display
+      const url = URL.createObjectURL(blob);
+      image.src = url;
+      URL.revokeObjectURL(url); // Clean up when done
+    }
+  } catch (error) {
+    console.error('Failed to capture screenshot:', error);
+  }
+};
+```
+
 ### The Constraints
 
 We can build a constraints object by passing it to the videoConstraints prop. This gets passed into getUserMedia method. Please take a look at the MDN docs to get an understanding how this works.
@@ -95,14 +118,23 @@ const WebcamCapture = () => (
     width={1280}
     videoConstraints={videoConstraints}
   >
-    {({ getScreenshot }) => (
-      <button
-        onClick={() => {
-          const imageSrc = getScreenshot()
-        }}
-      >
-        Capture photo
-      </button>
+    {({ getScreenshot, getScreenshotBlob }) => (
+      <div>
+        <button
+          onClick={() => {
+            const imageSrc = getScreenshot()
+          }}
+        >
+          Capture photo (base64)
+        </button>
+        <button
+          onClick={async () => {
+            const blob = await getScreenshotBlob();
+          }}
+        >
+          Capture photo (blob)
+        </button>
+      </div>
     )}
   </Webcam>
 );
@@ -121,7 +153,7 @@ const WebcamCapture = () => {
   const webcamRef = React.useRef(null);
   const capture = React.useCallback(
     () => {
-      const imageSrc = webcamRef.current.getScreenshot();
+      const imageSrc = webcamRef.current.getScreenshot(); // or getScreenshotBlob()
     },
     [webcamRef]
   );

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -205,35 +205,35 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
     );
   }
 
-  getScreenshotBlob(screenshotDimensions?: ScreenshotDimensions): Promise<Blob | null> {
+  async getScreenshotBlob(screenshotDimensions?: ScreenshotDimensions): Promise<Blob | null> {
     const { state, props } = this;
 
-    if (!state.hasUserMedia) return Promise.resolve(null);
+    if (!state.hasUserMedia) return null;
 
     const canvas = this.getCanvas(screenshotDimensions);
-    if (!canvas) return Promise.resolve(null);
+    if (!canvas) return null;
 
     if (typeof canvas.toBlob !== 'function') {
-      return Promise.reject(new Error('Canvas toBlob is not supported'));
+      throw new Error('Canvas toBlob is not supported');
     }
 
-    return new Promise((resolve, reject) => {
-      try {
+    try {
+      const blob = await new Promise<Blob | null>((resolve) => {
         canvas.toBlob(
-          (blob) => {
-            if (!blob) {
-              reject(new Error('Failed to convert canvas to blob'));
-              return;
-            }
-            resolve(blob);
-          },
+          (blob) => resolve(blob),
           props.screenshotFormat,
           props.screenshotQuality
         );
-      } catch (error) {
-        reject(error instanceof Error ? error : new Error('Failed to capture screenshot'));
+      });
+
+      if (!blob) {
+        throw new Error('Failed to convert canvas to blob');
       }
-    });
+
+      return blob;
+    } catch (error) {
+      throw error instanceof Error ? error : new Error('Failed to capture screenshot');
+    }
   }
 
   getCanvas(screenshotDimensions?: ScreenshotDimensions) {

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -213,14 +213,26 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
     const canvas = this.getCanvas(screenshotDimensions);
     if (!canvas) return Promise.resolve(null);
 
-    return new Promise((resolve) => {
-      canvas.toBlob(
-        (blob) => {
-          resolve(blob);
-        },
-        props.screenshotFormat,
-        props.screenshotQuality
-      );
+    if (typeof canvas.toBlob !== 'function') {
+      return Promise.reject(new Error('Canvas toBlob is not supported'));
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        canvas.toBlob(
+          (blob) => {
+            if (!blob) {
+              reject(new Error('Failed to convert canvas to blob'));
+              return;
+            }
+            resolve(blob);
+          },
+          props.screenshotFormat,
+          props.screenshotQuality
+        );
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error('Failed to capture screenshot'));
+      }
     });
   }
 

--- a/src/react-webcam.tsx
+++ b/src/react-webcam.tsx
@@ -50,6 +50,7 @@ interface ScreenshotDimensions {
 
 interface ChildrenProps {
   getScreenshot: (screenshotDimensions?: ScreenshotDimensions) => string | null;
+  getScreenshotBlob: (screenshotDimensions?: ScreenshotDimensions) => Promise<Blob | null>;
 }
 
 export type WebcamProps = Omit<React.HTMLProps<HTMLVideoElement>, "ref"> & {
@@ -202,6 +203,25 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
       canvas &&
       canvas.toDataURL(props.screenshotFormat, props.screenshotQuality)
     );
+  }
+
+  getScreenshotBlob(screenshotDimensions?: ScreenshotDimensions): Promise<Blob | null> {
+    const { state, props } = this;
+
+    if (!state.hasUserMedia) return Promise.resolve(null);
+
+    const canvas = this.getCanvas(screenshotDimensions);
+    if (!canvas) return Promise.resolve(null);
+
+    return new Promise((resolve) => {
+      canvas.toBlob(
+        (blob) => {
+          resolve(blob);
+        },
+        props.screenshotFormat,
+        props.screenshotQuality
+      );
+    });
   }
 
   getCanvas(screenshotDimensions?: ScreenshotDimensions) {
@@ -404,6 +424,7 @@ export default class Webcam extends React.Component<WebcamProps, WebcamState> {
 
     const childrenProps: ChildrenProps = {
       getScreenshot: this.getScreenshot.bind(this),
+      getScreenshotBlob: this.getScreenshotBlob.bind(this),
     };
 
     return (


### PR DESCRIPTION
Thanks for this very useful lib!

I noticed that encoding bigger screenshots as base64 dataurls takes a lot of CPU. In my testing, `Blob` is way faster. If you want to do some downstream processing, directly mapping the canvas to a `Blob` is also way more memory efficient.

Let me know if missed something.